### PR TITLE
Sync with master branches of gtk crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,16 +12,20 @@ path = "pangocairo-sys"
 version = "0.1.0"
 
 [dependencies.glib]
-version = "0.1.2"
+git = "https://github.com/gtk-rs/glib"
+version = "0.1.1"
 
 [dependencies.pango]
-version = "0.1.2"
+git = "https://github.com/gtk-rs/pango"
+version = "0.1.1"
 
 [dependencies.cairo-rs]
-version = "0.1.2"
+git = "https://github.com/gtk-rs/cairo"
+version = "0.1.1"
 
 [lib]
 name = "pangocairo"
 
-[dev-dependencies]
-gtk = "0.1"
+[dev-dependencies.gtk]
+git = "https://github.com/gtk-rs/gtk"
+version = "0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pangocairo"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Reizner Evgeniy <razrfalcon@gmail.com>"]
 description = "Rust bindings for the PangoCairo library"
 repository = "https://github.com/razrfalcon/pangocairo-rs"

--- a/pangocairo-sys/Cargo.toml
+++ b/pangocairo-sys/Cargo.toml
@@ -12,13 +12,16 @@ build = "build.rs"
 libc = "0.2"
 
 [dependencies.cairo-sys-rs]
-version = "0.3.3"
+git = "https://github.com/gtk-rs/cairo"
+version = "0.3.2"
 
 [dependencies.pango-sys]
-version = "0.3.3"
+git = "https://github.com/gtk-rs/sys"
+version = "0.3.2"
 
 [dependencies.glib-sys]
-version = "0.3.3"
+git = "https://github.com/gtk-rs/sys"
+version = "0.3.2"
 
 [build-dependencies]
 pkg-config = "0.3.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ impl PangoFontMapExt for pango::FontMap {
 
 
 pub trait PangoContextExt {
-    //fn get_font_options(&self) -> cairo::FontOptions;
+    fn get_font_options(&self) -> Option<cairo::FontOptions>;
     fn set_font_options(&self, options: cairo::FontOptions);
     fn get_resolution(&self) -> f64;
     fn set_resolution(&self, dpi: f64);
@@ -67,13 +67,11 @@ pub trait PangoContextExt {
 }
 
 impl PangoContextExt for pango::Context {
-    //fn get_font_options(&self) -> cairo::FontOptions {
-    //    let font_options: cairo::FontOptions = unsafe {
-    //        cairo::FontOptions::from_raw(ffi::pango_cairo_context_get_font_options(self.to_glib_none().0))
-    //    };
-    //    font_options.ensure_status();
-    //    font_options
-    //}
+    fn get_font_options(&self) -> Option<cairo::FontOptions> {
+        unsafe {
+            from_glib_none(ffi::pango_cairo_context_get_font_options(self.to_glib_none().0))
+        }
+    }
 
     fn set_font_options(&self, options: cairo::FontOptions) {
         unsafe {


### PR DESCRIPTION
For some reason ([ref?](https://github.com/gtk-rs/gtk/issues/465)), master branches of gtk crates are "older" in version than the latest crate version. For now, let the master branch just track the other master branches instead of the crate versions.

Merge only after https://github.com/gtk-rs/cairo/pull/120 is merged.