### PR TITLE
fix compilation error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,23 +13,20 @@ version = "0.1.0"
 
 [dependencies.glib]
 git = "https://github.com/gtk-rs/glib"
-version = "0.1.1"
+version = "0.1.3"
 
 [dependencies.pango]
 git = "https://github.com/gtk-rs/pango"
-version = "0.1.1"
+version = "0.1.3"
 
 [dependencies.pango-sys]
 git = "https://github.com/gtk-rs/sys"
-version = "0.3.2"
+version = "0.3.4"
 
 [dependencies.cairo-rs]
 git = "https://github.com/gtk-rs/cairo"
-version = "0.1.1"
-
-[lib]
-name = "pangocairo"
+version = "0.1.3"
 
 [dev-dependencies.gtk]
 git = "https://github.com/gtk-rs/gtk"
-version = "0.1.1"
+version = "0.1.3"

--- a/pangocairo-sys/Cargo.toml
+++ b/pangocairo-sys/Cargo.toml
@@ -8,23 +8,23 @@ license = "MIT"
 keywords = ["cairo", "pango", "ffi"]
 build = "build.rs"
 
+[lib]
+name = "pangocairo_sys"
+
 [dependencies]
-libc = "0.2"
+libc = "0.2.22"
 
 [dependencies.cairo-sys-rs]
 git = "https://github.com/gtk-rs/cairo"
-version = "0.3.2"
+version = "0.3.4"
 
 [dependencies.pango-sys]
 git = "https://github.com/gtk-rs/sys"
-version = "0.3.2"
+version = "0.3.4"
 
 [dependencies.glib-sys]
 git = "https://github.com/gtk-rs/sys"
-version = "0.3.2"
+version = "0.3.4"
 
 [build-dependencies]
-pkg-config = "0.3.7"
-
-[lib]
-name = "pangocairo_sys"
+pkg-config = "0.3.9"

--- a/pangocairo-sys/src/lib.rs
+++ b/pangocairo-sys/src/lib.rs
@@ -57,7 +57,7 @@ extern "C" {
     //=========================================================================
     // Other functions
     //=========================================================================
-    pub fn pango_cairo_context_get_font_options(context: *mut pango::PangoContext) -> *const cairo::cairo_font_options_t;
+    pub fn pango_cairo_context_get_font_options(context: *mut pango::PangoContext) -> *mut cairo::cairo_font_options_t;
     pub fn pango_cairo_context_get_resolution(context: *mut pango::PangoContext) -> c_double;
     pub fn pango_cairo_context_get_shape_renderer(context: *mut pango::PangoContext, data: *mut gpointer) -> PangoCairoShapeRendererFunc;
     pub fn pango_cairo_context_set_font_options(context: *mut pango::PangoContext, options: *const cairo::cairo_font_options_t);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ pub use font_map::FontMap;
 
 
 pub trait PangoContextExt {
-    fn get_font_options(&self) -> Option<cairo::FontOptions>;
+    fn get_font_options(&self) -> cairo::FontOptions;
     fn set_font_options(&self, options: cairo::FontOptions);
     fn get_resolution(&self) -> f64;
     fn set_resolution(&self, dpi: f64);
@@ -40,15 +40,15 @@ pub trait PangoContextExt {
 }
 
 impl PangoContextExt for pango::Context {
-    fn get_font_options(&self) -> Option<cairo::FontOptions> {
+    fn get_font_options(&self) -> cairo::FontOptions {
         unsafe {
-            from_glib_none(ffi::pango_cairo_context_get_font_options(self.to_glib_none().0))
+            cairo::FontOptions::from_raw_full(ffi::pango_cairo_context_get_font_options(self.to_glib_none().0))
         }
     }
 
     fn set_font_options(&self, options: cairo::FontOptions) {
         unsafe {
-            ffi::pango_cairo_context_set_font_options(self.to_glib_none().0, options.get_ptr())
+            ffi::pango_cairo_context_set_font_options(self.to_glib_none().0, options.to_raw_none())
         }
     }
 


### PR DESCRIPTION
When using the last version of the library, I got a compilation because ```cairo``` removed the ```glib``` dependencies for some ```struct```. This PR aims to fix this. 

I've also make a little update to the ```Cargo.toml``` files to improve readability and update the depedencies to the last version. I hope it's ok for you ? 