### PR TITLE
Provide `gobject_ffi` for the `glib_wrapper!` macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,7 @@ version = "0.1.3"
 [dev-dependencies.gtk]
 git = "https://github.com/gtk-rs/gtk"
 version = "0.1.3"
+
+[dependencies.gobject-sys]
+git = "https://github.com/gtk-rs/sys"
+version = "0.3.4"

--- a/src/font_map.rs
+++ b/src/font_map.rs
@@ -1,6 +1,7 @@
 use cairo;
 use ffi;
 use glib::translate::*;
+use gobject_ffi;
 use pango;
 use pango_sys;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ extern crate pango;
 extern crate pango_sys;
 #[macro_use]
 extern crate glib;
+extern crate gobject_sys as gobject_ffi;
 
 use glib::translate::*;
 


### PR DESCRIPTION
As of https://github.com/gtk-rs/glib/commit/b36de4e9c38fb7be534fb7f17ec9eae3b2d3cd26, the macro `glib_wrapper!` requires `gobject_ffi` to be in scope. 