### PR TITLE
Remove GTK from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,10 +28,6 @@ version = "0.4.0"
 git = "https://github.com/gtk-rs/cairo"
 version = "0.2.0"
 
-[dev-dependencies.gtk]
-git = "https://github.com/gtk-rs/gtk"
-version = "0.2.0"
-
 [dependencies.gobject-sys]
 git = "https://github.com/gtk-rs/sys"
 version = "0.4.0"


### PR DESCRIPTION
This seems to build just fine without GTK as a dependency. It is not imported as `extern crate` either. So I have removed this dependency from the Cargo.toml file.